### PR TITLE
apache/linkis#4167

### DIFF
--- a/roles/linkis/tasks/main.yml
+++ b/roles/linkis/tasks/main.yml
@@ -32,10 +32,8 @@
 
 - name: 删除linkis-gateway-server-support-1.1.1.jar(#4167)
   file:
-    path: "/opt/apache-linkis-{{ LINKIS_VERSION }}/linkis-package/lib/linkis-spring-cloud-services/linkis-mg-gateway"
+    path: "/opt/apache-linkis-{{ LINKIS_VERSION }}/linkis-package/lib/linkis-spring-cloud-services/linkis-mg-gateway/linkis-gateway-server-support-1.1.1.jar"
     state: absent
-  with_items:
-    - linkis-gateway-server-support-1.1.1.jar
 
 - name: 创建安装配置
   template: 

--- a/roles/linkis/tasks/main.yml
+++ b/roles/linkis/tasks/main.yml
@@ -30,6 +30,13 @@
   become: true
   shell: "chown -R hadoop.hadoop /data /opt/apache-linkis-{{ LINKIS_VERSION }}"
 
+- name: 删除linkis-gateway-server-support-1.1.1.jar(#4167)
+  file:
+    path: "/opt/apache-linkis-{{ LINKIS_VERSION }}/linkis-package/lib/linkis-spring-cloud-services/linkis-mg-gateway"
+    state: absent
+  with_items:
+    - linkis-gateway-server-support-1.1.1.jar
+
 - name: 创建安装配置
   template: 
     src: "{{ item }}.j2"


### PR DESCRIPTION
delete jar
"/opt/apache-linkis-{{ LINKIS_VERSION }}/linkis-package/lib/linkis-spring-cloud-services/linkis-mg-gateway/linkis-gateway-server-support-1.1.1.jar"

https://github.com/apache/linkis/issues/4167

This problem is due to linkis-gateway-server-support-1.1.1.jar version incompatible as depicted by the following picture:
So Eureka could not extract services by the ps-cs which is the service name of early version(Currently it should be LINKIS-PS-PUBLICSERVICE)
You should go into the linkis install directory下lib/linkis-spring-cloud-services/linkis-mg-gateway to check linkis-gateway-server-support jar=>You should keep 1.3.* and delete 1.1.* releated jars. After restarting mg-gateway(sh sbin/linkis-daemon.sh restart mg-gateway), you can continue your job. 