### PR TITLE
[fix]linkis-cg-engineplugin微服务启动失败-#9

### DIFF
--- a/roles/linkis/templates/linkis-env.sh.j2
+++ b/roles/linkis/templates/linkis-env.sh.j2
@@ -146,7 +146,7 @@ PUBLICSERVICE_PORT=9105
 #LDAP_USER_NAME_FORMAT=cn=%s@xxx.com,OU=xxx,DC=xxx,DC=com
 
 ## java application default jvm memory
-export SERVER_HEAP_SIZE="512M"
+export SERVER_HEAP_SIZE="1024M"
 
 ##The decompression directory and the installation directory need to be inconsistent
 LINKIS_HOME={{ LINKIS_HOME }}


### PR DESCRIPTION
修复，因jvm内存配置不足导致的linkis微服务启动失败